### PR TITLE
Swift Package Manager fixes

### DIFF
--- a/FRAMEWORKNAME/Package.swift
+++ b/FRAMEWORKNAME/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:4.1
 //
 //  FRAMEWORKNAME.swift
 //  FRAMEWORKNAME
@@ -10,6 +11,20 @@ import PackageDescription
 
 let package = Package(
     name: "FRAMEWORKNAME",
+    products: [
+        .library(
+            name: "FRAMEWORKNAME",
+            targets: ["FRAMEWORKNAME"]),
+        ],
     dependencies: [],
-    exclude: ["Tests"]
+    targets: [
+        .target(
+            name: "FRAMEWORKNAME",
+            dependencies: [],
+            path: "Sources"),
+        .testTarget(
+            name: "FRAMEWORKNAMETests",
+            dependencies: ["FRAMEWORKNAME"],
+            path: "Tests")
+    ]
 )

--- a/FRAMEWORKNAME/README.md
+++ b/FRAMEWORKNAME/README.md
@@ -78,12 +78,17 @@ github "FRAMEWORKGITHUBNAME/FRAMEWORKNAME" ~> 0.0.1
 To use FRAMEWORKNAME as a [Swift Package Manager](https://swift.org/package-manager/) package just add the following in your Package.swift file.
 
 ``` swift
+// swift-tools-version:4.1
+
 import PackageDescription
 
 let package = Package(
     name: "HelloFRAMEWORKNAME",
     dependencies: [
-        .Package(url: "https://github.com/FRAMEWORKGITHUBNAME/FRAMEWORKNAME.git", .upToNextMajor(from: "0.0.1"))
+        .package(url: "https://github.com/FRAMEWORKGITHUBNAME/FRAMEWORKNAME.git", .upToNextMajor(from: "0.0.1"))
+    ],
+    targets: [
+        .target(name: "HelloFRAMEWORKNAME", dependencies: ["FRAMEWORKNAME"])
     ]
 )
 ```


### PR DESCRIPTION
- Moved unit tests file to an inner folder inside Tests, which is used
by swift to make a "tests target"
- Updated `Package` to `package` (new syntax) in README
- Added targets section in README demonstrating how to link the
dependency
- Several updates to Package.swift

Example of public repo where these changes are working: https://github.com/gobetti/RxCocoaNetworking/commit/67af2653625bd00d58c330539faab212b13a8642